### PR TITLE
chore: update default config to pin github action digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
   "ignorePresets": [":prHourlyLimit2", ":prConcurrentLimit20"],
   "labels": ["help wanted", "dependencies"],
   "minimumReleaseAge": "3 days",

--- a/default.json
+++ b/default.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:base", "helpers:pinGitHubActionDigestsToSemver"],
   "ignorePresets": [":prHourlyLimit2", ":prConcurrentLimit20"],
   "labels": ["help wanted", "dependencies"],
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
### Summary

This updates the default renovate config to extend `helpers:pinGitHubActionDigestsToSemver`. This makes it so when a GitHub action version is updated the immutable digest SHA is used instead of the mutable version tag.

For example:
Without digest pinning: `actions/checkout@v4`
With digest pinning: `actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0`

### Additional Documentation

https://docs.renovatebot.com/modules/manager/github-actions/